### PR TITLE
Fix build configuration for production deployment

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,12 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: true, // Allow access from any host
+    allowedHosts: [
+      'events.build2learn.in',
+      'localhost',
+      '.build2learn.in', // Allow all subdomains
+    ],
     proxy: {
       '/api': {
         target: 'http://localhost:8000',


### PR DESCRIPTION
- Convert postcss.config.js to CommonJS syntax to resolve build error
- Add allowedHosts configuration for events.build2learn.in domain
- Enable host: true to allow external access in Vite server

Fixes SyntaxError: Unexpected token 'export' in PostCSS config Resolves "host not allowed" error for production domain